### PR TITLE
Replace unfill-toggle with unfill-cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,16 @@ Otherwise:
 
     M-x unfill-region
     M-x unfill-paragraph
-    M-x unfill-toggle
+    M-x unfill-cycle
+
+### unfill-cycle
+
+By default ~unfill-cycle~ toggles the paragraph at point between filled and unfilled.
+
+You can customize this behavior by setting the list-variable ~unfill-functions~ in your emacs-config.
+~unfill-cycle~ will then format the paragraph according to the first function on it's first call, to the second function on it's second consecutive call, etc.
+
+    (setq unfill-functions (list 'fill-paragraph 'unfill-paragraph 'my-own-function-for-formating-paragraphs))
 
 <hr>
 

--- a/unfill.el
+++ b/unfill.el
@@ -60,23 +60,21 @@ This variable should be a list of functions that don't take arguments.")
 (defun unfill-cycle ()
   "Cycle formating of the current region, or current paragraph if no region active."
   (interactive)
-  (funcall (cycle-on-repetition unfill-functions))
-  )
+  (funcall (unfill-cycle-on-repetition unfill-functions)))
 
-(defvar repetition-counter 0
+(defvar unfill-repetition-counter 0
   "How often cycle-on-repetition has been called in a row using the same command.")
 
 ;;;###autoload
-(defun cycle-on-repetition (list-of-expressions)
+(defun unfill-cycle-on-repetition (list-of-expressions)
   "Return the first element from the list on the first call,
    the second expression on the second consecutive call etc"
   (interactive)
   (if (equal this-command last-command)
-      (setq repetition-counter (+ repetition-counter 1))
-    (setq repetition-counter 0)
-    )
+      (setq unfill-repetition-counter (+ unfill-repetition-counter 1))
+    (setq unfill-repetition-counter 0))
   (nth
-   (mod repetition-counter (length list-of-expressions))
+   (mod unfill-repetition-counter (length list-of-expressions))
    list-of-expressions))
 
 

--- a/unfill.el
+++ b/unfill.el
@@ -52,20 +52,39 @@ This command does the inverse of `fill-region'."
   (let ((fill-column most-positive-fixnum))
     (fill-region start end)))
 
-;;;###autoload
-(defun unfill-toggle ()
-  "Toggle filling/unfilling of the current region, or current paragraph if no region active."
-  (interactive)
-  (let (deactivate-mark
-        (fill-column
-         (if (eq last-command this-command)
-             (progn (setq this-command nil)
-                    most-positive-fixnum)
-           fill-column)))
-    (call-interactively 'fill-paragraph)))
+(defvar unfill-functions (list 'fill-paragraph 'unfill-paragraph)
+  "Functions for unfill-cycle to format the paragraph at point.
+This variable should be a list of functions that don't take arguments.")
 
 ;;;###autoload
-(define-obsolete-function-alias 'toggle-fill-unfill 'unfill-toggle "0.2")
+(defun unfill-cycle ()
+  "Cycle formating of the current region, or current paragraph if no region active."
+  (interactive)
+  (funcall (cycle-on-repetition unfill-functions))
+  )
+
+(defvar repetition-counter 0
+  "How often cycle-on-repetition has been called in a row using the same command.")
+
+;;;###autoload
+(defun cycle-on-repetition (list-of-expressions)
+  "Return the first element from the list on the first call,
+   the second expression on the second consecutive call etc"
+  (interactive)
+  (if (equal this-command last-command)
+      (setq repetition-counter (+ repetition-counter 1))
+    (setq repetition-counter 0)
+    )
+  (nth
+   (mod repetition-counter (length list-of-expressions))
+   list-of-expressions))
+
+
+;;;###autoload
+(define-obsolete-function-alias 'toggle-fill-unfill 'unfill-cycle "0.2")
+
+;;;###autoload
+(define-obsolete-function-alias 'toggle-toggle 'unfill-cycle "0.4")
 
 (provide 'unfill)
 ;;; unfill.el ends here


### PR DESCRIPTION
Also introduce the variable unfill-functions.

This addresses #7, if accepted this will be the first of 2 pull requests. The second one would add 2 new functions for formating paragraphs/regions with semantic lines.

I am not sure how the desired behavior is if there is a region, please check that especially carefully