### PR TITLE
Add function unfill-newest-entry-in-kill-ring

### DIFF
--- a/unfill.el
+++ b/unfill.el
@@ -53,6 +53,18 @@ This command does the inverse of `fill-region'."
     (fill-region start end)))
 
 ;;;###autoload
+(defun unfill-newest-entry-in-kill-ring (&optional replace)
+  "Add to kill ring the unfilled version of the newest entry.
+This command unfills with 'unfill-paragraph'.  If REPLACE is
+non-nil, replace the newest entry in the kill-ring instead of
+just adding the unfilled version."
+  (interactive "P")
+  (with-temp-buffer
+    (insert (car kill-ring))
+    (unfill-region (point-min) (point-max))
+    (kill-new (buffer-string) replace)))
+
+;;;###autoload
 (defun unfill-toggle ()
   "Toggle filling/unfilling of the current region, or current paragraph if no region active."
   (interactive)


### PR DESCRIPTION
Often when yanking text from Emacs to outside of Emacs i need it to be unfilled. 
In my init file I advise `kill-ring-save` and `kill-region` as to take a prefix argument, in which case the last element of the kill ring is unfilled.  I thought a function that does that could be provided by `unfill` (the user could then use it interactively, or advise it after whatever command they want).