### PR TITLE
Fill docstring.

### DIFF
--- a/unfill.el
+++ b/unfill.el
@@ -54,7 +54,8 @@ This command does the inverse of `fill-region'."
 
 ;;;###autoload
 (defun unfill-toggle ()
-  "Toggle filling/unfilling of the current region, or current paragraph if no region active."
+  "Toggle filling/unfilling of the current region, or current
+paragraph if no region active."
   (interactive)
   (let (deactivate-mark
         (fill-column


### PR DESCRIPTION
Silences compiler warning for docstring wider than 80 characters.